### PR TITLE
freature / Add profile and logout buttons to HomeScreen

### DIFF
--- a/app/src/main/java/com/moviles/yetify/YetifyApp.kt
+++ b/app/src/main/java/com/moviles/yetify/YetifyApp.kt
@@ -1,17 +1,14 @@
 package com.moviles.yetify
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.*
 import androidx.navigation.navArgument
 import com.moviles.yetify.ui.theme.screens.*
 import com.moviles.yetify.viewmodel.AuthViewModel
+import com.moviles.yetify.datastore.UserPreferences
+import androidx.compose.ui.platform.LocalContext
 
 /**
  * Root composable for the Yetify application.
@@ -26,6 +23,10 @@ fun YetifyApp() {
 
     // Instance of the authentication ViewModel
     val authViewModel: AuthViewModel = viewModel()
+
+    // Instance of UserPreferences to retrieve stored user data
+    val context = LocalContext.current
+    val userPreferences = remember { UserPreferences(context) }
 
     // Navigation host defining all available routes/screens
     NavHost(
@@ -154,7 +155,14 @@ fun YetifyApp() {
                 onActivitiesClick = { /* TODO: Navigate to activities screen */ },
                 onProgressClick = { /* TODO: Navigate to progress screen */ },
                 onTasksClick = { navController.navigate("tasks") }, // Navigate to tasks screen
-                onReadingsClick = { /* TODO: Navigate to readings screen */ }
+                onReadingsClick = { /* TODO: Navigate to readings screen */ },
+                onLogout = {
+                    // Clear back stack and return to welcome screen
+                    navController.navigate("welcome") {
+                        popUpTo("main") { inclusive = true }
+                    }
+                },
+                userPreferences = userPreferences
             )
         }
 

--- a/app/src/main/java/com/moviles/yetify/common/Constants.kt
+++ b/app/src/main/java/com/moviles/yetify/common/Constants.kt
@@ -1,6 +1,6 @@
 package com.moviles.yetify.common
 
 object Constants {
-    const val API_BASE_URL = "http://192.168.100.10:5003/"
+    const val API_BASE_URL = "http://192.168.100.107:5003/"
     //const val API_BASE_URL = "http://10.0.2.2:5003/"
 }

--- a/app/src/main/java/com/moviles/yetify/datastore/UserPreferences.kt
+++ b/app/src/main/java/com/moviles/yetify/datastore/UserPreferences.kt
@@ -5,36 +5,51 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.moviles.yetify.models.User
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 private val Context.dataStore by preferencesDataStore("user_prefs")
 
 class UserPreferences(private val context: Context) {
 
     companion object {
-        val USER_ID = intPreferencesKey("user_id")
-        val TOKEN = stringPreferencesKey("token")
+        private val USER_ID = intPreferencesKey("user_id")
+        private val USER_NAME = stringPreferencesKey("user_name")
+        private val EMAIL = stringPreferencesKey("email")
+        private val BIRTHDAY = stringPreferencesKey("birthday")
+        private val REGISTRATION_DATE = stringPreferencesKey("registration_date")
+        private val TOKEN = stringPreferencesKey("token")
+
+        private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
     }
 
-    val userId: Flow<Int?> = context.dataStore.data.map { prefs ->
-        prefs[USER_ID]
-    }
+    val userId: Flow<Int?> = context.dataStore.data.map { it[USER_ID] }
+    val userName: Flow<String?> = context.dataStore.data.map { it[USER_NAME] }
+    val email: Flow<String?> = context.dataStore.data.map { it[EMAIL] }
+    val birthday: Flow<String?> = context.dataStore.data.map { it[BIRTHDAY] }
+    val registrationDate: Flow<String?> = context.dataStore.data.map { it[REGISTRATION_DATE] }
+    val token: Flow<String?> = context.dataStore.data.map { it[TOKEN] }
 
-    val token: Flow<String?> = context.dataStore.data.map { prefs ->
-        prefs[TOKEN]
-    }
-
-    suspend fun saveUser(id: Int, token: String) {
+    suspend fun saveUser(user: User) {
         context.dataStore.edit { prefs ->
-            prefs[USER_ID] = id
+            prefs[USER_ID] = user.id
+            prefs[USER_NAME] = user.userName
+            prefs[EMAIL] = user.email
+            prefs[BIRTHDAY] = dateFormat.format(user.birthday)
+            prefs[REGISTRATION_DATE] = dateFormat.format(user.registrationDate)
+            prefs[TOKEN] = user.token
+        }
+    }
+    suspend fun saveToken(token: String) {
+        context.dataStore.edit { prefs ->
             prefs[TOKEN] = token
         }
     }
 
     suspend fun clearUser() {
-        context.dataStore.edit { prefs ->
-            prefs.clear()
-        }
+        context.dataStore.edit { it.clear() }
     }
 }

--- a/app/src/main/java/com/moviles/yetify/models/LoginResponse.kt
+++ b/app/src/main/java/com/moviles/yetify/models/LoginResponse.kt
@@ -1,5 +1,6 @@
 package com.moviles.yetify.models
 
+import java.util.Date
 /**
  * Represents the user data returned after successful login.
  */
@@ -7,8 +8,7 @@ data class LoginResponse(
     val id: Int,
     val userName: String,
     val email: String,
-    val role: String,
-    val birthday: String,
-    val registrationDate: String,
+    val birthday: Date,
+    val registrationDate: Date,
     val token: String
 )

--- a/app/src/main/java/com/moviles/yetify/models/User.kt
+++ b/app/src/main/java/com/moviles/yetify/models/User.kt
@@ -1,15 +1,16 @@
 package com.moviles.yetify.models
 
 import androidx.room.PrimaryKey
+import java.util.Date
 /**
  * Data class representing a user object received from the API.
- * Matches the structure of the C# UserDto used in responses (excluding password for security).
+ * Matches the structure of the C# UserDto use- in responses (excluding password for security).
  */
 data class User(
     val id: Int,                        // Unique user identifier
     val userName: String,              // Display name
     val email: String,                 // User's email address
-    val birthday: String,              // Date of birth (as ISO string, e.g., "2000-01-01")
-    val registrationDate: String,      // Date the user registered (also ISO format)
+    val birthday: Date,              // Date of birth
+    val registrationDate: Date,      // Date the user registered
     val token: String                  // JWT token received from login (manually added)
 )

--- a/app/src/main/java/com/moviles/yetify/network/ApiService.kt
+++ b/app/src/main/java/com/moviles/yetify/network/ApiService.kt
@@ -9,6 +9,7 @@ import com.moviles.yetify.models.RegisterRequest
 import com.moviles.yetify.models.ResetPasswordRequest
 import com.moviles.yetify.models.UserTask
 import com.moviles.yetify.viewmodel.UserTaskViewModel
+import com.moviles.yetify.models.User
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -61,4 +62,7 @@ interface ApiService {
 
     @POST("/api/Auth/register")
     suspend fun register(@Body request: RegisterRequest): Response<ApiResponse>
+
+    @GET("api/User/{id}")
+    suspend fun getUserById(@Path("id") id: Int): User
 }

--- a/app/src/main/java/com/moviles/yetify/network/RetrofitInstance.kt
+++ b/app/src/main/java/com/moviles/yetify/network/RetrofitInstance.kt
@@ -1,11 +1,11 @@
 package com.moviles.yetify.network
 
 import android.app.Application
+import com.google.gson.GsonBuilder
 import com.moviles.yetify.common.Constants.API_BASE_URL
 import com.moviles.yetify.datastore.UserPreferences
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -41,12 +41,16 @@ object RetrofitInstance {
             .build()
     }
 
-    // Retrofit instance that uses the interceptor
+    // Retrofit instance that uses the interceptor and custom Gson for date handling
     val api: ApiService by lazy {
+        val gson = GsonBuilder()
+            .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS")
+            .create()
+
         Retrofit.Builder()
             .baseUrl(API_BASE_URL)
             .client(okHttpClient)
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
             .create(ApiService::class.java)
     }

--- a/app/src/main/java/com/moviles/yetify/ui/theme/screens/HomeScreen.kt
+++ b/app/src/main/java/com/moviles/yetify/ui/theme/screens/HomeScreen.kt
@@ -1,20 +1,25 @@
 package com.moviles.yetify.ui.theme.screens
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moviles.yetify.R
+import com.moviles.yetify.datastore.UserPreferences
 
 @Composable
 fun HomeScreen(
@@ -22,39 +27,60 @@ fun HomeScreen(
     onProgressClick: () -> Unit,
     onTasksClick: () -> Unit,
     onReadingsClick: () -> Unit,
+    onLogout: () -> Unit,
+    userPreferences: UserPreferences,
     modifier: Modifier = Modifier
 ) {
+    // State variables to control visibility of dialogs
+    var showProfileDialog by remember { mutableStateOf(false) }
+    var showSettingsDialog by remember { mutableStateOf(false) }
+
+    // Retrieve user data stored in DataStore (persisted values)
+    val userName by userPreferences.userName.collectAsState(initial = "")
+    val email by userPreferences.email.collectAsState(initial = "")
+    val birthday by userPreferences.birthday.collectAsState(initial = "")
+    val registrationDate by userPreferences.registrationDate.collectAsState(initial = "")
+
+    // Root container of the HomeScreen
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(Color.White) // White background for a clean and simple look
     ) {
+        // Main vertical layout
         Column(modifier = Modifier.fillMaxSize()) {
 
-            // Encabezado
+            // Top App Bar containing Profile and Settings buttons
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color(0xFFB3E5FC))
+                    .background(Color(0xFFB3E5FC)) // Light blue background for header
                     .padding(16.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_profile),
-                    contentDescription = "Perfil",
-                    modifier = Modifier.size(32.dp),
-                    tint = Color.White
-                )
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_settings),
-                    contentDescription = "Ajustes",
-                    modifier = Modifier.size(32.dp),
-                    tint = Color.White
-                )
+                // Profile icon button on the left
+                IconButton(onClick = { showProfileDialog = true }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_profile),
+                        contentDescription = "Perfil",
+                        modifier = Modifier.size(40.dp),
+                        tint = Color.White
+                    )
+                }
+
+                // Settings icon button on the right
+                IconButton(onClick = { showSettingsDialog = true }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_settings),
+                        contentDescription = "Ajustes",
+                        modifier = Modifier.size(40.dp),
+                        tint = Color.White
+                    )
+                }
             }
 
-            // Imagen del Yeti
+            // Centered Yeti mascot image
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -64,45 +90,101 @@ fun HomeScreen(
                 Image(
                     painter = painterResource(id = R.drawable.yeti_complete_smiling),
                     contentDescription = "Logo de Yetify",
-                    modifier = Modifier.size(250.dp)
+                    modifier = Modifier.size(250.dp) // Friendly mascot size
                 )
             }
 
-            // Botones (cuatro en dos filas)
+            // Grid of four action buttons (2 rows, 2 buttons per row)
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                // First row: Activities and Progress
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
-                    HomeButton("Actividades", R.drawable.ic_activities, onActivitiesClick,modifier = Modifier.weight(1f)
-                    )
-                    HomeButton("Progreso", R.drawable.ic_progress, onProgressClick,modifier = Modifier.weight(1f))
+                    HomeButton("Actividades", R.drawable.ic_activities, onActivitiesClick, Modifier.weight(1f))
+                    HomeButton("Progreso", R.drawable.ic_progress, onProgressClick, Modifier.weight(1f))
                 }
 
+                // Second row: Tasks and Readings
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
-                    HomeButton("Mis Tareas", R.drawable.ic_tasks, onTasksClick, modifier = Modifier.weight(1f)
-                    )
-                    HomeButton("Lecturas", R.drawable.ic_readings, onReadingsClick,modifier = Modifier.weight(1f)
-                    )
+                    HomeButton("Mis Tareas", R.drawable.ic_tasks, onTasksClick, Modifier.weight(1f))
+                    HomeButton("Lecturas", R.drawable.ic_readings, onReadingsClick, Modifier.weight(1f))
                 }
             }
 
+            // Pushes the bottom box to the bottom of the screen
             Spacer(modifier = Modifier.weight(1f))
 
-            // Pie de página decorativo
+            // Bottom decorative footer bar
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(24.dp)
                     .background(Color(0xFFB3E5FC))
+            )
+        }
+
+        // Animated Profile dialog displaying stored user info
+        AnimatedVisibility(
+            visible = showProfileDialog,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            AlertDialog(
+                onDismissRequest = { showProfileDialog = false },
+                confirmButton = {
+                    TextButton(onClick = { showProfileDialog = false }) {
+                        Text("¡Cerrar perfil!", fontWeight = FontWeight.Bold)
+                    }
+                },
+                // Title and body showing user information
+                title = { Text("Mi Perfil", fontSize = 20.sp, fontWeight = FontWeight.Bold) },
+                text = {
+                    Column {
+                        Text("Nombre de usuario: $userName")
+                        Text("Correo: $email")
+                        Text("Cumpleaños: $birthday")
+                    }
+                },
+                // Dialog background color
+                containerColor = Color(0xFFE1F5FE)
+            )
+        }
+
+        // Animated Settings dialog with logout confirmation
+        AnimatedVisibility(
+            visible = showSettingsDialog,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            AlertDialog(
+                onDismissRequest = { showSettingsDialog = false },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showSettingsDialog = false
+                        onLogout() // Triggers logout callback to parent
+                    }) {
+                        Text("Cerrar sesión", color = Color.Red, fontWeight = FontWeight.Bold)
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showSettingsDialog = false }) {
+                        Text("Cancelar")
+                    }
+                },
+                // Dialog title and confirmation message
+                title = { Text("Ajustes", fontSize = 20.sp, fontWeight = FontWeight.Bold) },
+                text = { Text("¿Deseas cerrar sesión de tu cuenta?") },
+                // Dialog background color
+                containerColor = Color(0xFFFFF8E1)
             )
         }
     }
@@ -115,21 +197,23 @@ fun HomeButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // Reusable composable for main navigation buttons
     Button(
         onClick = onClick,
         modifier = modifier
             .padding(8.dp)
             .height(120.dp),
-        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4EB1CB)),
-        shape = RoundedCornerShape(16.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4EB1CB)), // Themed blue
+        shape = RoundedCornerShape(20.dp),
         elevation = ButtonDefaults.buttonElevation(defaultElevation = 8.dp)
     ) {
+        // Icon + Text stacked vertically
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(
                 painter = painterResource(id = iconRes),
                 contentDescription = text,
                 tint = Color.White,
-                modifier = Modifier.size(32.dp)
+                modifier = Modifier.size(36.dp)
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
@@ -144,16 +228,19 @@ fun HomeButton(
     }
 }
 
-
 @Preview(showBackground = true)
 @Composable
 fun HomeScreenPreview() {
-    MaterialTheme {
-        HomeScreen(
-            onActivitiesClick = {},
-            onProgressClick = {},
-            onTasksClick = {},
-            onReadingsClick = {}
-        )
-    }
+    // Preview function to render the HomeScreen in Android Studio
+    val context = LocalContext.current
+    val prefs = remember { UserPreferences(context) }
+
+    HomeScreen(
+        onActivitiesClick = {},
+        onProgressClick = {},
+        onTasksClick = {},
+        onReadingsClick = {},
+        onLogout = {},
+        userPreferences = prefs
+    )
 }

--- a/app/src/main/java/com/moviles/yetify/ui/theme/screens/LoginScreen.kt
+++ b/app/src/main/java/com/moviles/yetify/ui/theme/screens/LoginScreen.kt
@@ -97,7 +97,7 @@ fun LoginScreen(
                     OutlinedTextField(
                         value = userName,
                         onValueChange = { userName = it },
-                        label = { Text("Correo electrónico", color = Color.White) },
+                        label = { Text("Nombre de usuario", color = Color.White) },
                         leadingIcon = {
                             Icon(Icons.Default.Email, contentDescription = "Correo", tint = Color.White)
                         },

--- a/app/src/main/java/com/moviles/yetify/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/moviles/yetify/viewmodel/AuthViewModel.kt
@@ -77,19 +77,25 @@ class AuthViewModel(application: Application) : AndroidViewModel(application) {
 
                 if (response.isSuccessful) {
                     // Parse response body safely
+                    Log.i("AuthViewModel", "Successful response")
                     response.body()?.let { apiResponse ->
                         val user = apiResponse.user
 
                         // Save user info in ViewModel state and preferences
                         userId = user.id
                         isAuthenticated = true
-                        prefs.saveUser(user.id, user.token)
 
                         // Emit success state with user data
                         _loginResult.value = LoginResult.Success(user)
+                        prefs.saveToken(user.token)
+
+                        val userResponse = RetrofitInstance.api.getUserById(userId!!)
+
+                        prefs.saveUser(userResponse)
 
                         // Debug logs for verification
                         Log.i("AuthViewModel", "Saved user id: ${prefs.userId.first()}")
+                        Log.i("AuthViewModel", "Saved username: ${prefs.userName.first()}")
                         Log.i("AuthViewModel", "Saved token: ${prefs.token.first()}")
                         Log.i("AuthViewModel", "Login success. User: $user")
                     } ?: run {

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -7,5 +7,6 @@
         <domain includeSubdomains="true">190.61.84.172</domain>
         <domain includeSubdomains="true">192.168.100.107</domain>
         <domain includeSubdomains="true">192.168.100.1</domain>
+        <domain includeSubdomains="true">172.17.50.120</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
This PR introduces two interactive buttons to the top bar of the HomeScreen:

A profile button that displays user data (username, email, birthday) fetched from UserPreferences (DataStore).

A settings button that opens a dialog for logout confirmation.

These additions enhance user experience by giving quick access to personal data and session control.

Changes made:

Added profile button hat shows an animated dialog with user info from DataStore.

Added settings button with confirmation dialog to trigger logout.

Improved UI with child-friendly design: friendly colors and rounded shapes.

Integrated UserPreferences as a parameter to fetch user data reactively.

Acceptance criteria:
✓ Profile icon opens dialog with correct user data (username, email, birthday).
✓ Settings icon opens confirmation dialog with "Cerrar sesión" option.
✓ Clicking "Cerrar sesión" calls the onLogout() callback.

Test cases:

Name: Display profile info correctly
Steps:

Launch the app and login

Tap the profile icon  on top left

Observe the dialog
Expected: Dialog shows username, email and birthday of the user

Name: Logout dialog confirmation
Steps:

Tap the settings icon  on top right

Confirm the logout
Expected: Dialog asks for confirmation; tapping "Cerrar sesión" logs the user out

Name: Profile dialog cancellation
Steps:

Tap profile icon

Tap "¡Cerrar perfil!"
Expected: Dialog closes without affecting the session